### PR TITLE
Fix go-google-golang-org-protobuf -> go-google-golang-org-protobuf-1.28

### DIFF
--- a/milran/packages/golang.scm
+++ b/milran/packages/golang.scm
@@ -886,7 +886,7 @@ port as a stream of bytes.")
     (description "Event based irc client library.")
     (license license:bsd-3)))
 
-(define-public go-google-golang-org-protobuf
+(define-public go-google-golang-org-protobuf-1.28
   (package
     (name "go-google-golang-org-protobuf")
     (version "1.28.1")


### PR DESCRIPTION
Signed-off-by: milran <milranmike@protonmail.com>